### PR TITLE
added an official dependency on rJava and 2 explicit references to it…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,8 @@ Imports:
     magrittr,
     lazyeval (>= 0.1.10),
     dbplyr,
-    dplyr (>= 0.5.0)
+    dplyr (>= 0.5.0),
+    rJava
 Suggests:
     Lahman (>= 3.0-1),
     nycflights13,

--- a/R/src-snowflakedb.R
+++ b/R/src-snowflakedb.R
@@ -186,8 +186,8 @@ src_snowflakedb <- function(user = NULL,
   )
   
   # initalize the JVM and set the snowflake properties
-  .jinit()
-  .jcall(
+  rJava::.jinit()
+  rJava::.jcall(
     "java/lang/System",
     "S",
     "setProperty",


### PR DESCRIPTION
… in the src_snowflakedb() function, to avoid the following error:

Error in .jinit() : could not find function ".jinit"
I was developing a package based on dplyr.snowflakedb, and could find no other way around the error.