### PR TITLE
remove account parameter

### DIFF
--- a/R/src-snowflakedb.R
+++ b/R/src-snowflakedb.R
@@ -222,9 +222,7 @@ src_snowflakedb <- function(user = NULL,
                 host,
                 ":",
                 as.character(port),
-                "/?account=",
-                account,
-                opts)
+                "/?",opts)
   message("URL: ", url)
   conn <-
     dbConnect(


### PR DESCRIPTION
Latest JDBC version do not accept account parameter, the info is taken only from the url:

https://docs.snowflake.net/manuals/user-guide/jdbc-configure.html